### PR TITLE
Update GitHub Actions tags to digests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Run a one-line script
       run: echo Hello, world!


### PR DESCRIPTION
Digests are considered more secure, as it fixes the action to a specific commit

Check out [GitHubs documentation](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for more information on why this is important.

I generated this change using [Frizbee](https://github.com/stacklok/frizbee),
an open source tool that flips tags to digests in Dockerfiles and GitHub Actions.
